### PR TITLE
never use util in browserify

### DIFF
--- a/debuglog.js
+++ b/debuglog.js
@@ -1,6 +1,6 @@
 var util = require('util');
 
-module.exports = util.debuglog || debuglog;
+module.exports = util && util.debuglog ? util.debuglog: debuglog;
 
 var debugs = {};
 var debugEnviron = process.env.NODE_DEBUG || '';

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   },
   "engines": {
     "node": "*"
+  },
+  "browser": {
+    "util": false
   }
 }


### PR DESCRIPTION
quick fix so that when used in browserify it avoids importing util and instead just always provides the debuglog function.
